### PR TITLE
Add missing google-auth dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
+google-auth
 beautifulsoup4
 pandas
 openpyxl


### PR DESCRIPTION
## Summary
- include `google-auth` in requirements to provide the `google` namespace for Gmail API usage

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django>=4.2)*
- `python gmail_amounts_to_excel.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c426d3e75083339ca3398bc12e2882