### PR TITLE
Add basic analytics for projects, clients, and services

### DIFF
--- a/gmail_ui/scraper/templates/scraper/home.html
+++ b/gmail_ui/scraper/templates/scraper/home.html
@@ -33,8 +33,20 @@
         <h2 class="mt-4">Total Amounts</h2>
         {{ totals_html|safe }}
         {% endif %}
-    {% else %}
+        {% if projects_html %}
+        <h2 class="mt-4">Projects</h2>
+        {{ projects_html|safe }}
+        {% endif %}
+        {% if clients_html %}
+        <h2 class="mt-4">Clients by Revenue</h2>
+        {{ clients_html|safe }}
+        {% endif %}
+        {% if services_html %}
+        <h2 class="mt-4">Services by Revenue</h2>
+        {{ services_html|safe }}
+        {% endif %}
+        {% else %}
         <p>No data available yet.</p>
-    {% endif %}
+        {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- classify email subjects into coarse service categories
- display aggregated totals for projects, clients, and services on the home page

## Testing
- `pip install -r requirements.txt`
- `python gmail_ui/manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68c6063c2c5c83338e852565bd9c9403