### PR TITLE
Handle comma thousands separators in amount parser

### DIFF
--- a/gmail_ui/scraper/gmail_amounts_to_excel.py
+++ b/gmail_ui/scraper/gmail_amounts_to_excel.py
@@ -299,7 +299,11 @@ def value_from_amount(raw):
             num = num.replace(",", "")
     else:
         if "," in num and "." not in num:
-            num = num.replace(",", ".")
+            parts = num.split(",")
+            if len(parts[-1]) == 3 and all(len(p) == 3 for p in parts[1:]):
+                num = "".join(parts)
+            else:
+                num = num.replace(",", ".")
     try:
         return float(num)
     except ValueError:


### PR DESCRIPTION
## Summary
- fix amount parsing to interpret commas as thousand separators when appropriate

## Testing
- `python -m py_compile gmail_ui/scraper/gmail_amounts_to_excel.py`
- `python - <<'PY'
from gmail_ui.scraper.gmail_amounts_to_excel import value_from_amount
samples = ["8,500 MAD", "8,500", "123,45", "1,234,567", "1,234.56", "1.234,56", "8.500"]
for s in samples:
    print(s, '->', value_from_amount(s))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c6d577cc38833380baba92b2024565