### PR TITLE
Avoid Gmail API service object overwrite

### DIFF
--- a/gmail_ui/scraper/gmail_amounts_to_excel.py
+++ b/gmail_ui/scraper/gmail_amounts_to_excel.py
@@ -588,7 +588,7 @@ def run_scraper(days=180, query=None, take=None, pick="max", account=None, email
                 dt_local = to_local_tz_naive(dt)
 
                 text_for_amounts = f"{subject}\n{body_text}"
-                service = detect_service(text_for_amounts)
+                service_type = detect_service(text_for_amounts)
                 amts = extract_amounts(text_for_amounts)
                 if not amts:
                     continue
@@ -613,7 +613,7 @@ def run_scraper(days=180, query=None, take=None, pick="max", account=None, email
                         "snippet": snippet,
                         "gmail_link": gmail_link(gm_id),
                         "account_email": email,
-                        "service": service,
+                        "service": service_type,
                     })
 
             if rows:
@@ -670,7 +670,7 @@ def run_scraper(days=180, query=None, take=None, pick="max", account=None, email
                     continue
 
                 text_for_amounts = f"{subject}\n{body_text}"
-                service = detect_service(text_for_amounts)
+                service_type = detect_service(text_for_amounts)
                 amts = extract_amounts(text_for_amounts)
                 if not amts:
                     continue
@@ -695,7 +695,7 @@ def run_scraper(days=180, query=None, take=None, pick="max", account=None, email
                         "snippet": snippet,
                         "gmail_link": gmail_link(mid),
                         "account_email": account_email,
-                        "service": service,
+                        "service": service_type,
                     })
 
             if rows:


### PR DESCRIPTION
## Summary
- Prevent Gmail API service resource from being overwritten during message parsing
- Keep service classification separate from the API client

## Testing
- `python -m py_compile gmail_ui/scraper/gmail_amounts_to_excel.py`
- `python gmail_ui/manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68c743c3fc788333bd23b5f18d867ff6