### PR TITLE
Remove tools section from dashboard

### DIFF
--- a/gmail_ui/scraper/templates/scraper/home.html
+++ b/gmail_ui/scraper/templates/scraper/home.html
@@ -190,31 +190,6 @@
         </div>
     </section>
     {% endif %}
-    {% if tools_html %}
-    <!-- Tools Section -->
-    <section>
-        <div class="row">
-            <div class="col-lg-6 mb-4 mb-lg-0">
-                <div class="card h-100">
-                    <div class="card-header">Tools by Revenue</div>
-                    <div class="card-body table-responsive">
-                        {{ tools_html|safe }}
-                    </div>
-                </div>
-            </div>
-            {% if top_tool %}
-            <div class="col-lg-6">
-                <div class="card h-100">
-                    <div class="card-header">Top Tool</div>
-                    <div class="card-body d-flex align-items-center justify-content-center">
-                        <p class="mb-0">{{ top_tool.tool }}: {{ top_tool.amount_value|floatformat:2 }}</p>
-                    </div>
-                </div>
-            </div>
-            {% endif %}
-        </div>
-    </section>
-    {% endif %}
     {% else %}
     <section>
         <div class="alert alert-warning" role="alert">No data available yet.</div>

--- a/gmail_ui/scraper/views.py
+++ b/gmail_ui/scraper/views.py
@@ -37,12 +37,6 @@ def extract_project(subject: str) -> str:
     return subject.strip()
 
 
-def extract_tool(sender_email: str) -> str:
-    """Return a simplified tool name from the sender's email domain."""
-    if not sender_email:
-        return "Unknown"
-    return sender_email.split("@")[-1].lower()
-
 def is_connected() -> bool:
     """Return True if an OAuth token file exists."""
     return any(TOKENS_DIR.glob("token-*.json"))
@@ -109,17 +103,6 @@ def home(request):
                         }
                     )
 
-                    df["tool"] = df["sender_email"].apply(extract_tool)
-                    tools = (
-                        df.groupby("tool")["amount_value"].sum()
-                        .reset_index()
-                        .sort_values("amount_value", ascending=False)
-                    )
-                    context["tools_html"] = tools.to_html(
-                        classes="table table-striped table-hover", index=False
-                    )
-                    if not tools.empty:
-                        context["top_tool"] = tools.iloc[0].to_dict()
             except Exception as exc:
                 context["error"] = str(exc)
     return render(request, "scraper/home.html", context)


### PR DESCRIPTION
## Summary
- Drop tool aggregation and top tool logic
- Delete Tools by Revenue and Top Tool blocks from home page template

## Testing
- `python gmail_ui/manage.py test`
- `python -m py_compile gmail_ui/scraper/views.py`


------
https://chatgpt.com/codex/tasks/task_e_68c74477bd5c83338628e617cccb5d9a