### PR TITLE
Add gamified progress tracking

### DIFF
--- a/gmail_ui/scraper/templates/scraper/home.html
+++ b/gmail_ui/scraper/templates/scraper/home.html
@@ -115,6 +115,22 @@
         {% endif %}
     </section>
 
+    <!-- Gamification Section -->
+    <section>
+        <div class="card mb-4">
+            <div class="card-header">Your Progress</div>
+            <div class="card-body">
+                <p class="mb-1">Runs: {{ run_count }}</p>
+                <p class="mb-1">Points: {{ points }}</p>
+                {% if badge %}
+                <p class="mb-3">Badge: {{ badge }}</p>
+                {% endif %}
+                <div class="progress" style="height: 20px;">
+                    <div class="progress-bar" role="progressbar" style="width: {{ progress }}%;" aria-valuenow="{{ progress }}" aria-valuemin="0" aria-valuemax="100"></div>
+                </div>
+            </div>
+        </div>
+    </section>
 
     {% if table_html %}
     <!-- Data Tables Section -->

--- a/gmail_ui/scraper/views.py
+++ b/gmail_ui/scraper/views.py
@@ -45,6 +45,7 @@ def is_connected() -> bool:
 def home(request):
     """Display results and allow the user to run the scraper."""
     connected = is_connected()
+    run_count = request.session.get("run_count", 0)
     context = {"connected": connected}
     if request.method == "POST":
         if not connected:
@@ -102,9 +103,19 @@ def home(request):
                             "values": services["amount_value"].tolist(),
                         }
                     )
-
+                run_count += 1
+                request.session["run_count"] = run_count
             except Exception as exc:
                 context["error"] = str(exc)
+    context["run_count"] = run_count
+    context["points"] = run_count * 10
+    if run_count >= 10:
+        context["badge"] = "Scraper Master"
+    elif run_count >= 5:
+        context["badge"] = "Scraper Apprentice"
+    elif run_count >= 1:
+        context["badge"] = "Scraper Novice"
+    context["progress"] = min(run_count, 10) * 10
     return render(request, "scraper/home.html", context)
 
 


### PR DESCRIPTION
## Summary
- track scraper run count in session and award badges and points
- add progress card to home page showing runs, points, badge and progress bar

## Testing
- `python -m py_compile gmail_ui/scraper/views.py`
- `python gmail_ui/manage.py check`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c745736f148333a0455a21eb07f62c