### PR TITLE
Fix template conditional syntax for badge classes

### DIFF
--- a/gmail_ui/scraper/templates/scraper/home.html
+++ b/gmail_ui/scraper/templates/scraper/home.html
@@ -202,7 +202,7 @@
                         {% endif %}
                         <div class="d-flex flex-wrap gap-2 mb-2">
                             {% for b in badges %}
-                            <span class="badge {{ 'bg-success' if b.unlocked else 'bg-secondary' }}">{{ b.name }}</span>
+                            <span class="badge {% if b.unlocked %}bg-success{% else %}bg-secondary{% endif %}">{{ b.name }}</span>
                             {% endfor %}
                         </div>
                         {% if next_target %}


### PR DESCRIPTION
## Summary
- fix TemplateSyntaxError by using Django template tags for badge class conditional

## Testing
- `python gmail_ui/manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68c811e065808333882c556fc3517d0a