### PR TITLE
Fix scraper monthly total accumulation

### DIFF
--- a/gmail_ui/scraper/tests.py
+++ b/gmail_ui/scraper/tests.py
@@ -1,0 +1,31 @@
+from django.test import RequestFactory, TestCase
+from unittest.mock import patch
+import pandas as pd
+
+from .views import home
+
+
+class HomeViewTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @patch('scraper.views.is_connected', return_value=True)
+    @patch('scraper.views.run_scraper')
+    def test_month_total_does_not_accumulate(self, mock_run_scraper, mock_is_connected):
+        df = pd.DataFrame({
+            'amount_value': [10, 20],
+            'amount_currency': ['USD', 'USD'],
+            'subject': ['Invoice - ProjectX', 'Payment - ProjectY'],
+            'sender_name': ['Client1', 'Client2'],
+        })
+        mock_run_scraper.return_value = df
+
+        request1 = self.factory.post('/')
+        request1.session = {}
+        home(request1)
+        self.assertEqual(request1.session['total_amount'], 30)
+
+        request2 = self.factory.post('/')
+        request2.session = request1.session
+        home(request2)
+        self.assertEqual(request2.session['total_amount'], 30)

--- a/gmail_ui/scraper/views.py
+++ b/gmail_ui/scraper/views.py
@@ -109,7 +109,10 @@ def home(request):
                             "values": services["amount_value"].tolist(),
                         }
                     )
-                    total_amount += df["amount_value"].sum()
+                    # Each run should reflect only the current month's total, not a
+                    # cumulative sum across runs.  Replace the session value with the
+                    # freshly computed total rather than adding to it.
+                    total_amount = df["amount_value"].sum()
                     request.session["total_amount"] = total_amount
             except Exception as exc:
                 context["error"] = str(exc)


### PR DESCRIPTION
## Summary
- Stop month total from accumulating across scraper runs by replacing session value instead of incrementing
- Add test ensuring running scraper repeatedly keeps the same monthly total

## Testing
- `python gmail_ui/manage.py test scraper`

------
https://chatgpt.com/codex/tasks/task_e_68c81de1ac908333b3faa79c0734f32f