### PR TITLE
Handle whitespace-separated numbers in amount parsing

### DIFF
--- a/gmail_ui/scraper/gmail_amounts_to_excel.py
+++ b/gmail_ui/scraper/gmail_amounts_to_excel.py
@@ -312,7 +312,7 @@ def value_from_amount(raw):
     m = re.findall(r"[-+]?\d[\d.,\s]*", cleaned)
     if not m:
         return None
-    num = m[0].strip().replace(" ", "")
+    num = re.sub(r"\s+", "", m[0])
     if "," in num and "." in num:
         last_comma = num.rfind(",")
         last_dot = num.rfind(".")

--- a/gmail_ui/scraper/tests.py
+++ b/gmail_ui/scraper/tests.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pandas as pd
 
 from .views import home
+from .gmail_amounts_to_excel import extract_amounts
 
 
 class HomeViewTests(TestCase):
@@ -29,3 +30,17 @@ class HomeViewTests(TestCase):
         request2.session = request1.session
         home(request2)
         self.assertEqual(request2.session['total_amount'], 30)
+
+
+class AmountParsingTests(TestCase):
+    def test_space_and_nbsp_equivalence(self):
+        texts = [
+            'Total: 8000 USD',
+            'Total: 8 000 USD',
+            'Total: 8\u00a0000 USD',
+        ]
+        for t in texts:
+            amts = extract_amounts(t)
+            self.assertEqual(len(amts), 1)
+            self.assertEqual(amts[0]['value'], 8000.0)
+            self.assertEqual(amts[0]['currency'], 'USD')


### PR DESCRIPTION
## Summary
- Ensure `value_from_amount` strips all whitespace, letting the scraper treat numbers like `8 000` the same as `8000`.
- Add unit test verifying amounts with spaces and non-breaking spaces parse to the correct numeric value.

## Testing
- `cd gmail_ui && python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c823749a608333beecd0ffd70d39e7