### PR TITLE
Improve reservation guest name extraction

### DIFF
--- a/gmail_ui/scraper/gmail_amounts_to_excel.py
+++ b/gmail_ui/scraper/gmail_amounts_to_excel.py
@@ -356,6 +356,7 @@ CLIENT_NAME_PATTERNS = [
     r"customer(?:\s+name)?\s*[:\-]\s*(.+)",
     r"nom\s+du\s+client\s*[:\-]\s*(.+)",
     r"nom\s+client\s*[:\-]\s*(.+)",
+    r"guest(?:\s+name)?\s*[:\-]\s*(.+)",
 ]
 
 
@@ -366,6 +367,12 @@ def clean_client_candidate(candidate: str) -> str:
             candidate = candidate.split(splitter)[0]
     candidate = re.split(r"\s{2,}", candidate)[0].strip()
     candidate = re.sub(r"\s+", " ", candidate)
+    candidate = re.sub(
+        r"\b(property|check[- ]?in|check[- ]?out|arrival|departure)\b.*",
+        "",
+        candidate,
+        flags=re.IGNORECASE,
+    )
     candidate = candidate.strip("-:;|. ")
     return candidate.strip()
 

--- a/gmail_ui/scraper/tests.py
+++ b/gmail_ui/scraper/tests.py
@@ -111,3 +111,13 @@ class ClientNameExtractionTests(TestCase):
         Amount: 300 USD
         """
         self.assertIsNone(extract_client_name(body))
+
+    def test_extracts_guest_name_from_reservation_email(self):
+        body = """
+        Hi Mohammed Kodidji,
+        Good news — you've got a new reservation!
+        Guest: Hamid Aberkane Property: Your apartment (Downtown)
+        Check-in: 2024-04-10
+        Check-out: 2024-04-12
+        """
+        self.assertEqual(extract_client_name(body), 'Hamid Aberkane')


### PR DESCRIPTION
## Summary
- extend the client name extraction patterns to cover guest-labelled reservation emails
- strip trailing reservation metadata such as property or check-in details from extracted names
- add a regression test for the reservation email format

## Testing
- `python gmail_ui/manage.py test scraper`


------
https://chatgpt.com/codex/tasks/task_e_68cadda52b6c8333a746186f2dc1b91e