### PR TITLE
Add expense tracking and contacts pages

### DIFF
--- a/gmail_ui/scraper/data_utils.py
+++ b/gmail_ui/scraper/data_utils.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import Iterable, List
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+DATA_DIR = BASE_DIR / "data"
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+EXPENSES_FILE = DATA_DIR / "expenses.json"
+CONTACTS_FILE = DATA_DIR / "contacts.json"
+
+
+@dataclass
+class Expense:
+    date: str
+    category: str
+    description: str
+    amount: Decimal
+    currency: str
+
+
+@dataclass
+class Contact:
+    name: str
+    company: str
+    category: str
+    phone: str
+    email: str
+    notes: str
+
+
+def _read_json(path: Path, default):
+    try:
+        if not path.exists():
+            return default
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return default
+
+
+def _write_json(path: Path, payload) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, ensure_ascii=False)
+
+
+def load_expenses() -> List[Expense]:
+    raw = _read_json(EXPENSES_FILE, [])
+    expenses: List[Expense] = []
+    for item in raw:
+        try:
+            amount = Decimal(str(item.get("amount", "0")))
+        except Exception:
+            amount = Decimal("0")
+        date_str = item.get("date") or ""
+        expenses.append(
+            Expense(
+                date=date_str,
+                category=str(item.get("category", "")),
+                description=str(item.get("description", "")),
+                amount=amount,
+                currency=str(item.get("currency", "MAD")) or "MAD",
+            )
+        )
+    expenses.sort(key=lambda e: e.date or "", reverse=True)
+    return expenses
+
+
+def save_expenses(expenses: Iterable[Expense]) -> None:
+    payload = [
+        {
+            "date": expense.date,
+            "category": expense.category,
+            "description": expense.description,
+            "amount": str(expense.amount),
+            "currency": expense.currency,
+        }
+        for expense in sorted(expenses, key=lambda e: e.date or "", reverse=True)
+    ]
+    _write_json(EXPENSES_FILE, payload)
+
+
+def calculate_expense_totals(expenses: Iterable[Expense]) -> dict[str, Decimal]:
+    totals: dict[str, Decimal] = {}
+    for expense in expenses:
+        currency = expense.currency or "MAD"
+        totals[currency] = totals.get(currency, Decimal("0")) + expense.amount
+    return totals
+
+
+def load_contacts() -> List[Contact]:
+    raw = _read_json(CONTACTS_FILE, [])
+    contacts: List[Contact] = []
+    for item in raw:
+        contacts.append(
+            Contact(
+                name=str(item.get("name", "")),
+                company=str(item.get("company", "")),
+                category=str(item.get("category", "other")) or "other",
+                phone=str(item.get("phone", "")),
+                email=str(item.get("email", "")),
+                notes=str(item.get("notes", "")),
+            )
+        )
+    contacts.sort(key=lambda c: (c.category.lower(), c.name.lower()))
+    return contacts
+
+
+def save_contacts(contacts: Iterable[Contact]) -> None:
+    payload = [
+        {
+            "name": contact.name,
+            "company": contact.company,
+            "category": contact.category,
+            "phone": contact.phone,
+            "email": contact.email,
+            "notes": contact.notes,
+        }
+        for contact in sorted(contacts, key=lambda c: (c.category.lower(), c.name.lower()))
+    ]
+    _write_json(CONTACTS_FILE, payload)
+
+
+def today_iso() -> str:
+    return date.today().isoformat()

--- a/gmail_ui/scraper/forms.py
+++ b/gmail_ui/scraper/forms.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from datetime import date
+
+from django import forms
+
+CURRENCY_CHOICES = [
+    ("MAD", "MAD"),
+    ("USD", "USD"),
+    ("EUR", "EUR"),
+    ("GBP", "GBP"),
+]
+
+CONTACT_CATEGORY_CHOICES = [
+    ("cleaning", "Cleaning"),
+    ("repair", "Repair"),
+    ("promotion", "Promotion"),
+    ("maintenance", "Maintenance"),
+    ("other", "Other"),
+]
+
+
+class ExpenseForm(forms.Form):
+    date = forms.DateField(
+        required=False,
+        widget=forms.DateInput(attrs={"type": "date", "class": "form-control"}),
+        help_text="Leave empty to use today's date.",
+    )
+    category = forms.CharField(
+        max_length=100,
+        widget=forms.TextInput(attrs={"class": "form-control"}),
+    )
+    description = forms.CharField(
+        max_length=255,
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 2, "class": "form-control"}),
+    )
+    amount = forms.DecimalField(
+        max_digits=12,
+        decimal_places=2,
+        min_value=0,
+        widget=forms.NumberInput(attrs={"class": "form-control", "step": "0.01"}),
+    )
+    currency = forms.ChoiceField(
+        choices=CURRENCY_CHOICES,
+        initial="MAD",
+        widget=forms.Select(attrs={"class": "form-select"}),
+    )
+
+
+class ContactForm(forms.Form):
+    name = forms.CharField(
+        max_length=120,
+        widget=forms.TextInput(attrs={"class": "form-control"}),
+    )
+    company = forms.CharField(
+        max_length=120,
+        required=False,
+        widget=forms.TextInput(attrs={"class": "form-control"}),
+        help_text="Optional company or organization name.",
+    )
+    category = forms.ChoiceField(
+        choices=CONTACT_CATEGORY_CHOICES,
+        initial="cleaning",
+        widget=forms.Select(attrs={"class": "form-select"}),
+    )
+    phone = forms.CharField(
+        max_length=50,
+        widget=forms.TextInput(attrs={"class": "form-control"}),
+    )
+    email = forms.EmailField(
+        required=False,
+        widget=forms.EmailInput(attrs={"class": "form-control"}),
+    )
+    notes = forms.CharField(
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 2, "class": "form-control"}),
+    )
+
+    def clean(self):
+        cleaned = super().clean()
+        phone = cleaned.get("phone")
+        email = cleaned.get("email")
+        if not phone and not email:
+            raise forms.ValidationError("Provide at least a phone number or an email address.")
+        return cleaned
+
+
+def default_expense_initial() -> dict[str, date | str]:
+    return {"date": date.today()}

--- a/gmail_ui/scraper/gmail_amounts_to_excel.py
+++ b/gmail_ui/scraper/gmail_amounts_to_excel.py
@@ -14,6 +14,7 @@ import json
 import getpass
 import imaplib
 import email
+from decimal import Decimal
 from email.header import decode_header, make_header
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
@@ -28,6 +29,11 @@ from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
+
+try:
+    from .data_utils import load_expenses, calculate_expense_totals
+except ImportError:  # pragma: no cover - allows running as a standalone script
+    from data_utils import load_expenses, calculate_expense_totals
 
 # ---- Excel styling imports (openpyxl) ----
 from openpyxl import load_workbook, Workbook
@@ -601,6 +607,72 @@ def write_totals_sheet(path: str | Path, df: pd.DataFrame) -> None:
     wb.save(path)
 
 
+def write_financial_summary(path: str | Path, df: pd.DataFrame) -> None:
+    """Write revenue, expenses, and net profit per currency to the workbook."""
+    expenses = load_expenses()
+    expense_totals = calculate_expense_totals(expenses)
+
+    if df.empty or "amount_currency" not in df.columns:
+        revenue_totals = {}
+    else:
+        raw_totals = df.groupby("amount_currency")["amount_value"].sum().to_dict()
+        revenue_totals = {
+            str(currency): Decimal(str(total)) for currency, total in raw_totals.items()
+        }
+
+    currencies = sorted(set(expense_totals) | set(revenue_totals))
+    rows = []
+    for currency in currencies:
+        revenue = revenue_totals.get(currency, Decimal("0"))
+        expense = expense_totals.get(currency, Decimal("0"))
+        net = revenue - expense
+        rows.append(
+            {
+                "Currency": currency,
+                "Revenue": float(revenue),
+                "Expenses": float(expense),
+                "Net Profit": float(net),
+            }
+        )
+
+    if not rows:
+        summary_df = pd.DataFrame(columns=["Currency", "Revenue", "Expenses", "Net Profit"])
+    else:
+        summary_df = pd.DataFrame(rows, columns=["Currency", "Revenue", "Expenses", "Net Profit"])
+
+    if not Path(path).exists():
+        return
+
+    with pd.ExcelWriter(path, engine="openpyxl", mode="a", if_sheet_exists="replace") as writer:
+        summary_df.to_excel(writer, sheet_name="financial_summary", index=False)
+
+    wb = load_workbook(path)
+    ws = wb["financial_summary"]
+
+    ws.freeze_panes = "A2"
+    if ws.max_row >= 1:
+        for cell in ws[1]:
+            cell.font = Font(bold=True)
+            cell.fill = HEADER_FILL
+            cell.border = THIN_BORDER
+
+    for row in range(2, ws.max_row + 1):
+        for col in range(2, ws.max_column + 1):
+            ws.cell(row=row, column=col).number_format = '#,##0.00'
+            ws.cell(row=row, column=col).border = THIN_BORDER
+
+    last_col_letter = ws.cell(row=1, column=ws.max_column).column_letter if ws.max_column else "A"
+    ws.auto_filter.ref = f"A1:{last_col_letter}{ws.max_row}"
+
+    data = list(ws.iter_rows(values_only=True))
+    for col_idx in range(1, ws.max_column + 1):
+        column_values = [row[col_idx - 1] for row in data] if data else []
+        width = best_fit_width(column_values)
+        ws.column_dimensions[ws.cell(row=1, column=col_idx).column_letter].width = width
+
+    wb.save(path)
+
+
 # ---------- Simple analytics ----------
 def most_profitable_service(df: pd.DataFrame) -> str | None:
     """Return the service with the highest total amount in the dataframe."""
@@ -694,8 +766,11 @@ def run_scraper(days=180, query=None, take=None, pick="max", account=None, email
                 merged.to_excel(EXCEL_PATH, index=False)
                 style_excel(EXCEL_PATH)
                 write_totals_sheet(EXCEL_PATH, merged)
+                write_financial_summary(EXCEL_PATH, merged)
             else:
                 merged = df
+                if Path(EXCEL_PATH).exists():
+                    write_financial_summary(EXCEL_PATH, merged)
             imap.logout()
         else:
             creds, account_email = load_creds_for_account(account)
@@ -781,8 +856,11 @@ def run_scraper(days=180, query=None, take=None, pick="max", account=None, email
                 merged.to_excel(EXCEL_PATH, index=False)
                 style_excel(EXCEL_PATH)
                 write_totals_sheet(EXCEL_PATH, merged)
+                write_financial_summary(EXCEL_PATH, merged)
             else:
                 merged = df
+                if Path(EXCEL_PATH).exists():
+                    write_financial_summary(EXCEL_PATH, merged)
         top_service = most_profitable_service(merged)
         if top_service:
             print(f"Most profitable service: {top_service}")

--- a/gmail_ui/scraper/templates/scraper/contacts.html
+++ b/gmail_ui/scraper/templates/scraper/contacts.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Contacts - Finance Toolkit</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <style>
+        :root {
+            --color-primary: #16a34a;
+            --color-secondary: #1e293b;
+            --color-bg: #f1f5f9;
+            --color-white: #ffffff;
+        }
+
+        body {
+            background-color: var(--color-bg);
+            color: var(--color-secondary);
+        }
+
+        .topbar {
+            background-color: var(--color-white);
+            flex-wrap: wrap;
+        }
+
+        .btn-primary {
+            background-color: var(--color-primary);
+            border-color: var(--color-primary);
+            color: var(--color-secondary);
+        }
+
+        .btn-primary:hover {
+            background-color: #15803d;
+            border-color: #15803d;
+            color: var(--color-white);
+        }
+
+        .card {
+            border: none;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            animation: fadeInUp 0.6s ease both;
+        }
+
+        .card-header {
+            background-color: var(--color-secondary);
+            color: var(--color-white);
+        }
+
+        .table { width: 100%; word-wrap: break-word; table-layout: fixed; }
+        .card-body.table-responsive { overflow-x: auto; }
+        .nav-link { color: var(--color-secondary); }
+        .nav-link.active { background-color: var(--color-primary); color: var(--color-white); }
+        @keyframes fadeInUp {
+            from {
+                opacity: 0;
+                transform: translate3d(0, 20px, 0);
+            }
+            to {
+                opacity: 1;
+                transform: none;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div>
+        <div class="topbar d-flex justify-content-between align-items-center p-3 border-bottom">
+            <div class="d-flex align-items-center gap-3 flex-wrap">
+                <h1 class="h5 mb-0">Finance Toolkit</h1>
+                <nav class="nav nav-pills small">
+                    <a class="nav-link" href="{% url 'home' %}">Dashboard</a>
+                    <a class="nav-link" href="{% url 'expenses' %}">Expenses</a>
+                    <a class="nav-link active" href="{% url 'contacts' %}">Contacts</a>
+                </nav>
+            </div>
+            <div class="d-flex align-items-center">
+                <a href="{% url 'home' %}" class="btn btn-outline-secondary">Back to Dashboard</a>
+            </div>
+        </div>
+        <div class="container my-4">
+            <section class="mb-4">
+                <div class="card">
+                    <div class="card-header">Add a Contact</div>
+                    <div class="card-body">
+                        <form method="post" class="row g-3">
+                            {% csrf_token %}
+                            <div class="col-md-4">
+                                <label class="form-label">{{ form.name.label }}</label>
+                                {{ form.name }}
+                                {% for error in form.name.errors %}
+                                    <div class="invalid-feedback d-block">{{ error }}</div>
+                                {% endfor %}
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">{{ form.company.label }}</label>
+                                {{ form.company }}
+                                {% if form.company.help_text %}
+                                    <div class="form-text">{{ form.company.help_text }}</div>
+                                {% endif %}
+                                {% for error in form.company.errors %}
+                                    <div class="invalid-feedback d-block">{{ error }}</div>
+                                {% endfor %}
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">{{ form.category.label }}</label>
+                                {{ form.category }}
+                                {% for error in form.category.errors %}
+                                    <div class="invalid-feedback d-block">{{ error }}</div>
+                                {% endfor %}
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">{{ form.phone.label }}</label>
+                                {{ form.phone }}
+                                {% for error in form.phone.errors %}
+                                    <div class="invalid-feedback d-block">{{ error }}</div>
+                                {% endfor %}
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">{{ form.email.label }}</label>
+                                {{ form.email }}
+                                {% for error in form.email.errors %}
+                                    <div class="invalid-feedback d-block">{{ error }}</div>
+                                {% endfor %}
+                            </div>
+                            <div class="col-12">
+                                <label class="form-label">{{ form.notes.label }}</label>
+                                {{ form.notes }}
+                                {% for error in form.notes.errors %}
+                                    <div class="invalid-feedback d-block">{{ error }}</div>
+                                {% endfor %}
+                            </div>
+                            {% if form.non_field_errors %}
+                                <div class="col-12">
+                                    {% for error in form.non_field_errors %}
+                                        <div class="alert alert-danger mb-0">{{ error }}</div>
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                            <div class="col-12">
+                                <button type="submit" class="btn btn-primary">Save Contact</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </section>
+
+            <section>
+                <div class="card">
+                    <div class="card-header">Contact Directory</div>
+                    <div class="card-body table-responsive">
+                        {% if contacts %}
+                            <table class="table table-striped table-hover table-sm align-middle">
+                                <thead>
+                                    <tr>
+                                        <th scope="col">Name</th>
+                                        <th scope="col">Company</th>
+                                        <th scope="col">Category</th>
+                                        <th scope="col">Phone</th>
+                                        <th scope="col">Email</th>
+                                        <th scope="col">Notes</th>
+                                        <th scope="col" class="text-end">Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for index, contact in contacts %}
+                                        <tr>
+                                            <td>{{ contact.name }}</td>
+                                            <td>{{ contact.company|default:"-" }}</td>
+                                            <td class="text-capitalize">{{ contact.category }}</td>
+                                            <td>{{ contact.phone|default:"-" }}</td>
+                                            <td>
+                                                {% if contact.email %}
+                                                    <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>
+                                                {% else %}
+                                                    -
+                                                {% endif %}
+                                            </td>
+                                            <td>{{ contact.notes|default:"-" }}</td>
+                                            <td class="text-end">
+                                                <form method="post" class="d-inline">
+                                                    {% csrf_token %}
+                                                    <input type="hidden" name="action" value="delete">
+                                                    <input type="hidden" name="index" value="{{ index }}">
+                                                    <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete this contact?');">
+                                                        <i class="fa fa-trash"></i>
+                                                    </button>
+                                                </form>
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        {% else %}
+                            <p class="mb-0">No contacts saved yet. Add your trusted partners to keep their details handy.</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </section>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/gmail_ui/scraper/templates/scraper/expenses.html
+++ b/gmail_ui/scraper/templates/scraper/expenses.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Expenses - Finance Toolkit</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <style>
+        :root {
+            --color-primary: #16a34a;
+            --color-secondary: #1e293b;
+            --color-bg: #f1f5f9;
+            --color-white: #ffffff;
+        }
+
+        body {
+            background-color: var(--color-bg);
+            color: var(--color-secondary);
+        }
+
+        .topbar {
+            background-color: var(--color-white);
+            flex-wrap: wrap;
+        }
+
+        .btn-primary {
+            background-color: var(--color-primary);
+            border-color: var(--color-primary);
+            color: var(--color-secondary);
+        }
+
+        .btn-primary:hover {
+            background-color: #15803d;
+            border-color: #15803d;
+            color: var(--color-white);
+        }
+
+        .card {
+            border: none;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            animation: fadeInUp 0.6s ease both;
+        }
+
+        .card-header {
+            background-color: var(--color-secondary);
+            color: var(--color-white);
+        }
+
+        .table { width: 100%; word-wrap: break-word; table-layout: fixed; }
+        .card-body.table-responsive { overflow-x: auto; }
+        .nav-link { color: var(--color-secondary); }
+        .nav-link.active { background-color: var(--color-primary); color: var(--color-white); }
+        @keyframes fadeInUp {
+            from {
+                opacity: 0;
+                transform: translate3d(0, 20px, 0);
+            }
+            to {
+                opacity: 1;
+                transform: none;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div>
+        <div class="topbar d-flex justify-content-between align-items-center p-3 border-bottom">
+            <div class="d-flex align-items-center gap-3 flex-wrap">
+                <h1 class="h5 mb-0">Finance Toolkit</h1>
+                <nav class="nav nav-pills small">
+                    <a class="nav-link" href="{% url 'home' %}">Dashboard</a>
+                    <a class="nav-link active" href="{% url 'expenses' %}">Expenses</a>
+                    <a class="nav-link" href="{% url 'contacts' %}">Contacts</a>
+                </nav>
+            </div>
+            <div class="d-flex align-items-center">
+                <a href="{% url 'download_excel' %}" class="btn btn-primary me-2">Download Excel</a>
+                <a href="{% url 'home' %}" class="btn btn-outline-secondary">Back to Dashboard</a>
+            </div>
+        </div>
+        <div class="container my-4">
+            <section class="mb-4">
+                <div class="card">
+                    <div class="card-header">Add an Expense</div>
+                    <div class="card-body">
+                        <form method="post" class="row g-3">
+                            {% csrf_token %}
+                            <div class="col-md-3">
+                                <label class="form-label">{{ form.date.label }}</label>
+                                {{ form.date }}
+                                {% if form.date.help_text %}
+                                    <div class="form-text">{{ form.date.help_text }}</div>
+                                {% endif %}
+                                {% for error in form.date.errors %}
+                                    <div class="invalid-feedback d-block">{{ error }}</div>
+                                {% endfor %}
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label">{{ form.category.label }}</label>
+                                {{ form.category }}
+                                {% for error in form.category.errors %}
+                                    <div class="invalid-feedback d-block">{{ error }}</div>
+                                {% endfor %}
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label">{{ form.amount.label }}</label>
+                                {{ form.amount }}
+                                {% for error in form.amount.errors %}
+                                    <div class="invalid-feedback d-block">{{ error }}</div>
+                                {% endfor %}
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label">{{ form.currency.label }}</label>
+                                {{ form.currency }}
+                                {% for error in form.currency.errors %}
+                                    <div class="invalid-feedback d-block">{{ error }}</div>
+                                {% endfor %}
+                            </div>
+                            <div class="col-12">
+                                <label class="form-label">{{ form.description.label }}</label>
+                                {{ form.description }}
+                                {% for error in form.description.errors %}
+                                    <div class="invalid-feedback d-block">{{ error }}</div>
+                                {% endfor %}
+                            </div>
+                            {% if form.non_field_errors %}
+                                <div class="col-12">
+                                    {% for error in form.non_field_errors %}
+                                        <div class="alert alert-danger mb-0">{{ error }}</div>
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                            <div class="col-12">
+                                <button type="submit" class="btn btn-primary">Save Expense</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </section>
+
+            <section class="mb-4">
+                <div class="row g-4">
+                    <div class="col-md-4">
+                        <div class="card h-100">
+                            <div class="card-header">Revenue Totals</div>
+                            <div class="card-body">
+                                {% if revenue_totals %}
+                                    <ul class="list-unstyled mb-0">
+                                        {% for currency, total in revenue_totals %}
+                                            <li class="d-flex justify-content-between"><span>{{ currency }}</span> <span>{{ total|floatformat:2 }}</span></li>
+                                        {% endfor %}
+                                    </ul>
+                                {% elif has_excel %}
+                                    <p class="mb-0">No revenue recorded yet.</p>
+                                {% else %}
+                                    <p class="mb-0">Run the scraper to generate revenue totals.</p>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="card h-100">
+                            <div class="card-header">Expense Totals</div>
+                            <div class="card-body">
+                                {% if expense_totals %}
+                                    <ul class="list-unstyled mb-0">
+                                        {% for currency, total in expense_totals %}
+                                            <li class="d-flex justify-content-between"><span>{{ currency }}</span> <span>{{ total|floatformat:2 }}</span></li>
+                                        {% endfor %}
+                                    </ul>
+                                {% else %}
+                                    <p class="mb-0">No expenses saved yet.</p>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="card h-100">
+                            <div class="card-header">Net Profit</div>
+                            <div class="card-body">
+                                {% if net_profit %}
+                                    <ul class="list-unstyled mb-0">
+                                        {% for currency, total in net_profit %}
+                                            <li class="d-flex justify-content-between"><span>{{ currency }}</span> <span>{{ total|floatformat:2 }}</span></li>
+                                        {% endfor %}
+                                    </ul>
+                                {% else %}
+                                    <p class="mb-0">Net profit will appear once you add revenue or expenses.</p>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section>
+                <div class="card">
+                    <div class="card-header">Expense History</div>
+                    <div class="card-body table-responsive">
+                        {% if expenses %}
+                            <table class="table table-striped table-hover table-sm align-middle">
+                                <thead>
+                                    <tr>
+                                        <th scope="col">Date</th>
+                                        <th scope="col">Category</th>
+                                        <th scope="col">Description</th>
+                                        <th scope="col">Amount</th>
+                                        <th scope="col">Currency</th>
+                                        <th scope="col" class="text-end">Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for index, expense in expenses %}
+                                        <tr>
+                                            <td>{{ expense.date|default:"-" }}</td>
+                                            <td>{{ expense.category }}</td>
+                                            <td>{{ expense.description|default:"-" }}</td>
+                                            <td>{{ expense.amount|floatformat:2 }}</td>
+                                            <td>{{ expense.currency }}</td>
+                                            <td class="text-end">
+                                                <form method="post" class="d-inline">
+                                                    {% csrf_token %}
+                                                    <input type="hidden" name="action" value="delete">
+                                                    <input type="hidden" name="index" value="{{ index }}">
+                                                    <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete this expense?');">
+                                                        <i class="fa fa-trash"></i>
+                                                    </button>
+                                                </form>
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        {% else %}
+                            <p class="mb-0">No expenses recorded yet.</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </section>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/gmail_ui/scraper/templates/scraper/home.html
+++ b/gmail_ui/scraper/templates/scraper/home.html
@@ -104,13 +104,20 @@
         }
         .achievement-badge i { font-size:2rem; margin-bottom:0.25rem; }
         .achievement-badge.locked { filter:grayscale(1); opacity:0.5; }
+        .nav-link { color: var(--color-secondary); }
+        .nav-link.active { background-color: var(--color-primary); color: var(--color-white); }
     </style>
 </head>
 <body>
     <div>
         <div class="topbar d-flex justify-content-between align-items-center p-3 border-bottom">
-            <div class="d-flex align-items-center">
-                <h1 class="h5 mb-0">Dashboard</h1>
+            <div class="d-flex align-items-center gap-3 flex-wrap">
+                <h1 class="h5 mb-0">Finance Toolkit</h1>
+                <nav class="nav nav-pills small">
+                    <a class="nav-link active" href="{% url 'home' %}">Dashboard</a>
+                    <a class="nav-link" href="{% url 'expenses' %}">Expenses</a>
+                    <a class="nav-link" href="{% url 'contacts' %}">Contacts</a>
+                </nav>
             </div>
             <div class="d-flex align-items-center">
                 <button class="btn btn-link me-2" id="themeToggle"><i class="fa fa-moon"></i></button>

--- a/gmail_ui/scraper/urls.py
+++ b/gmail_ui/scraper/urls.py
@@ -7,4 +7,6 @@ urlpatterns = [
     path('download/', views.download_excel, name='download_excel'),
     path('login/', views.login_view, name='login'),
     path('logout/', views.logout_view, name='logout'),
+    path('expenses/', views.expenses, name='expenses'),
+    path('contacts/', views.contacts, name='contacts'),
 ]

--- a/gmail_ui/scraper/views.py
+++ b/gmail_ui/scraper/views.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import json
 from datetime import date
+from decimal import Decimal
 
 import pandas as pd
 
@@ -8,7 +9,22 @@ from django.http import FileResponse, HttpResponse
 from django.shortcuts import redirect, render
 from django.contrib.auth import logout
 
-from .gmail_amounts_to_excel import run_scraper
+from .forms import ContactForm, ExpenseForm, default_expense_initial
+from .data_utils import (
+    Contact,
+    Expense,
+    calculate_expense_totals,
+    load_contacts,
+    load_expenses,
+    save_contacts,
+    save_expenses,
+    today_iso,
+)
+from .gmail_amounts_to_excel import (
+    run_scraper,
+    load_existing_excel,
+    write_financial_summary,
+)
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 EXCEL_PATH = BASE_DIR.parent / "email_amounts.xlsx"
@@ -43,6 +59,26 @@ def extract_project(subject: str) -> str:
 def is_connected() -> bool:
     """Return True if an OAuth token file exists."""
     return any(TOKENS_DIR.glob("token-*.json"))
+
+
+def refresh_financial_summary() -> None:
+    """Regenerate the financial summary sheet when expenses change."""
+    if EXCEL_PATH.exists():
+        df = load_existing_excel(str(EXCEL_PATH))
+        write_financial_summary(EXCEL_PATH, df)
+
+
+def revenue_totals() -> dict[str, Decimal]:
+    """Return a mapping of currency to revenue total from the Excel file."""
+    if not EXCEL_PATH.exists():
+        return {}
+    df = load_existing_excel(str(EXCEL_PATH))
+    if df.empty or "amount_currency" not in df.columns:
+        return {}
+    totals = (
+        df.groupby("amount_currency")["amount_value"].sum().to_dict()
+    )
+    return {str(currency): Decimal(str(total)) for currency, total in totals.items()}
 
 
 def home(request):
@@ -181,6 +217,97 @@ def home(request):
     context["next_target"] = next_target
     context["next_badge"] = next_badge
     return render(request, "scraper/home.html", context)
+
+
+def expenses(request):
+    expenses_list = load_expenses()
+    if request.method == "POST":
+        action = request.POST.get("action")
+        if action == "delete":
+            try:
+                index = int(request.POST.get("index", "-1"))
+            except ValueError:
+                index = -1
+            if 0 <= index < len(expenses_list):
+                expenses_list.pop(index)
+                save_expenses(expenses_list)
+                refresh_financial_summary()
+            return redirect("expenses")
+
+        form = ExpenseForm(request.POST)
+        if form.is_valid():
+            data = form.cleaned_data
+            expense = Expense(
+                date=(data["date"].isoformat() if data["date"] else today_iso()),
+                category=data["category"],
+                description=data.get("description", ""),
+                amount=data["amount"],
+                currency=data["currency"],
+            )
+            expenses_list.append(expense)
+            save_expenses(expenses_list)
+            refresh_financial_summary()
+            return redirect("expenses")
+        expense_form = form
+    else:
+        expense_form = ExpenseForm(initial=default_expense_initial())
+
+    expense_totals = calculate_expense_totals(expenses_list)
+    revenue = revenue_totals()
+    currencies = sorted(set(expense_totals) | set(revenue))
+    net_profit = {
+        currency: revenue.get(currency, Decimal("0")) - expense_totals.get(currency, Decimal("0"))
+        for currency in currencies
+    }
+
+    context = {
+        "form": expense_form,
+        "expenses": list(enumerate(expenses_list)),
+        "expense_totals": sorted(expense_totals.items()),
+        "revenue_totals": sorted(revenue.items()),
+        "net_profit": sorted(net_profit.items()),
+        "has_excel": EXCEL_PATH.exists(),
+    }
+    return render(request, "scraper/expenses.html", context)
+
+
+def contacts(request):
+    contact_list = load_contacts()
+    if request.method == "POST":
+        action = request.POST.get("action")
+        if action == "delete":
+            try:
+                index = int(request.POST.get("index", "-1"))
+            except ValueError:
+                index = -1
+            if 0 <= index < len(contact_list):
+                contact_list.pop(index)
+                save_contacts(contact_list)
+            return redirect("contacts")
+
+        form = ContactForm(request.POST)
+        if form.is_valid():
+            data = form.cleaned_data
+            contact = Contact(
+                name=data["name"],
+                company=data.get("company", ""),
+                category=data["category"],
+                phone=data["phone"],
+                email=data.get("email", ""),
+                notes=data.get("notes", ""),
+            )
+            contact_list.append(contact)
+            save_contacts(contact_list)
+            return redirect("contacts")
+        contact_form = form
+    else:
+        contact_form = ContactForm()
+
+    context = {
+        "form": contact_form,
+        "contacts": list(enumerate(contact_list)),
+    }
+    return render(request, "scraper/contacts.html", context)
 
 
 def download_excel(request):


### PR DESCRIPTION
## Summary
- add an expenses page to capture costs, compute net profit, and link the workbook summary
- add a contacts directory page for partner details with create/delete actions
- update the dashboard navigation and Excel export to include financial summaries

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68f623de14188333927c9eaff05c2a01